### PR TITLE
refactor: rewrite the register template

### DIFF
--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -1,0 +1,18 @@
+<?php
+    return [
+        'register' => [
+            'form' => [
+                'email' => 'E-Mail',
+                'name' => 'Name',
+                'password' => 'Passwort',
+                'password_confirmation' => 'Passwort bestätigen',
+                'signin' => 'Du hast bereits ein Konto? :signin',
+                'signup' => "Los geht's!",
+            ],
+            'headline' => 'Konto erstellen',
+            'link' => [
+                'login' => 'Anmelden'
+            ],
+            'subtitle' => 'Beginne deine Momente'
+        ],
+    ];

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -4,15 +4,18 @@
             'form' => [
                 'email' => 'E-Mail',
                 'name' => 'Name',
+                'newsletter' => 'Ich akzeptiere den Newsletter von EventGuru',
                 'password' => 'Passwort',
                 'password_confirmation' => 'Passwort bestätigen',
                 'signin' => 'Du hast bereits ein Konto? :signin',
                 'signup' => "Los geht's!",
+                'tos' => 'Ich akzeptiere die :terms_of_service',
             ],
             'headline' => 'Konto erstellen',
             'link' => [
-                'login' => 'Anmelden'
+                'login' => 'Anmelden',
+                'tos' => 'AGBs',
             ],
-            'subtitle' => 'Beginne deine Momente'
+            'subtitle' => 'Beginne deine Momente',
         ],
     ];

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -4,15 +4,18 @@
             'form' => [
                 'email' => 'Email',
                 'name' => 'Name',
+                'newsletter' => 'I accept newsletter by EventGuru',
                 'password' => 'Password',
                 'password_confirmation' => 'Confirm Password',
                 'signin' => 'You already have an account? :signin',
                 'signup' => "Let's go!",
+                'tos' => 'I accept the :terms_of_service',
             ],
             'headline' => 'Create account',
             'link' => [
-                'login' => 'Login'
+                'login' => 'Login',
+                'tos' => 'Terms of Service',
             ],
-            'subtitle' => 'Start your moments'
+            'subtitle' => 'Start your moments',
         ],
     ];

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -1,0 +1,18 @@
+<?php
+    return [
+        'register' => [
+            'form' => [
+                'email' => 'Email',
+                'name' => 'Name',
+                'password' => 'Password',
+                'password_confirmation' => 'Confirm Password',
+                'signin' => 'You already have an account? :signin',
+                'signup' => "Let's go!",
+            ],
+            'headline' => 'Create account',
+            'link' => [
+                'login' => 'Login'
+            ],
+            'subtitle' => 'Start your moments'
+        ],
+    ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,31 +28,37 @@
                 <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
             </div>
 
-            {{-- TODO: Figure out how to turn off password confirmation
             <div class="mt-4">
-                <x-label for="password_confirmation" value="{{ __('messages.register.form.password') }}" />
+                <x-label for="password_confirmation" value="{{ __('messages.register.form.password_confirmation') }}" />
                 <x-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
             </div>
-            --}}
 
             @if (Laravel\Jetstream\Jetstream::hasTermsAndPrivacyPolicyFeature())
-                {{-- TODO: Check whether we actually need a Terms and Privacy Policy Feature
                 <div class="mt-4">
                     <x-label for="terms">
                         <div class="flex items-center">
                             <x-checkbox name="terms" id="terms" required />
 
                             <div class="ms-2">
-                                {!! __('I agree to the :terms_of_service and :privacy_policy', [
-                                        'terms_of_service' => '<a target="_blank" href="'.route('terms.show').'" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">'.__('Terms of Service').'</a>',
-                                        'privacy_policy' => '<a target="_blank" href="'.route('policy.show').'" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">'.__('Privacy Policy').'</a>',
+                                {!! __('messages.register.form.tos', [
+                                        'terms_of_service' => '<a target="_blank" href="'.route('terms.show').'" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">'.__('messages.register.link.tos').'</a>',
                                 ]) !!}
                             </div>
                         </div>
                     </x-label>
                 </div>
-                --}}
             @endif
+
+            <div class="mt-4">
+                <x-label for="terms">
+                    <div class="flex items-center">
+                        <x-checkbox name="newsletter" id="newsletter" required />
+                        <div class="ms-2">
+                            {{ __('messages.register.form.newsletter') }}
+                        </div>
+                    </div>
+                </x-label>
+            </div>
 
             <div class="row mt-4">
                 {{-- Compensate for !important padding on x-button with max-w --}}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,35 +1,42 @@
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">
-            <x-authentication-card-logo />
+            <div class="offset-sm-3 col-6 text-center">
+                <x-authentication-card-logo />
+                <h1 class="display-2">{{ __('messages.register.headline') }}</h1>
+                <p>{{ __('messages.register.subtitle') }}</p>
+            </div>
         </x-slot>
 
         <x-validation-errors class="mb-4" />
 
-        <form method="POST" action="{{ route('register') }}">
+        <form method="POST" action="{{ route('register') }}" class="offset-sm-3 col-6">
             @csrf
 
             <div>
-                <x-label for="name" value="{{ __('Name') }}" />
+                <x-label for="name" value="{{ __('messages.register.form.name') }}" />
                 <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
             </div>
 
             <div class="mt-4">
-                <x-label for="email" value="{{ __('Email') }}" />
+                <x-label for="email" value="{{ __('messages.register.form.email') }}" />
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
             </div>
 
             <div class="mt-4">
-                <x-label for="password" value="{{ __('Password') }}" />
+                <x-label for="password" value="{{ __('messages.register.form.password') }}" />
                 <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
             </div>
 
+            {{-- TODO: Figure out how to turn off password confirmation
             <div class="mt-4">
-                <x-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
+                <x-label for="password_confirmation" value="{{ __('messages.register.form.password') }}" />
                 <x-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
             </div>
+            --}}
 
             @if (Laravel\Jetstream\Jetstream::hasTermsAndPrivacyPolicyFeature())
+                {{-- TODO: Check whether we actually need a Terms and Privacy Policy Feature
                 <div class="mt-4">
                     <x-label for="terms">
                         <div class="flex items-center">
@@ -44,16 +51,23 @@
                         </div>
                     </x-label>
                 </div>
+                --}}
             @endif
 
-            <div class="flex items-center justify-end mt-4">
-                <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('login') }}">
-                    {{ __('Already registered?') }}
-                </a>
-
-                <x-button class="ms-4">
-                    {{ __('Register') }}
+            <div class="row mt-4">
+                {{-- Compensate for !important padding on x-button with max-w --}}
+                <x-button class="col-12 mx-auto justify-center border-0 bg-primary normal-case tracking-normal !max-w-[calc(100%-1.5rem)]">
+                    {{ __('messages.register.form.signup') }}
                 </x-button>
+            </div>
+            {{-- TODO: Add Social Login --}}
+
+            <div class="row mt-4">
+                <p class="col-12 text-center">
+                    {!! __('messages.register.form.signin', [
+                        'signin' => '<a class="underline text-sm text-primary hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="'.route('login').'">'.__('messages.register.link.login').'</a>'
+                    ]) !!}
+                </p>
             </div>
         </form>
     </x-authentication-card>

--- a/resources/views/components/authentication-card.blade.php
+++ b/resources/views/components/authentication-card.blade.php
@@ -1,9 +1,9 @@
-<div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900">
-    <div>
+<div class="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <header class="row">
         {{ $logo }}
-    </div>
+    </header>
 
-    <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg">
+    <div class="row bg-white dark:!bg-gray-800">
         {{ $slot }}
     </div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,7 @@ export default {
         './storage/framework/views/*.php',
         './resources/views/**/*.blade.php',
     ],
-
+    //prefix: 'tw-',
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
This is more in line with what the Figma design envisioned. I prepared the template for translations. You can update your `.env` file for German strings going forward.

https://laravel.com/docs/11.x/localization#configuring-the-locale

It's unfortunate that we are using TailwindCSS as this carries with it rulesets using `!important` which cannot be easily overwritten further. I'd know how to do that in (S)CSS but not in TailwindCSS.

So instead I found creative workarounds.