### PR TITLE
feat: trigger dependabot with access to secrets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - develop
-      - 'dependabot/**'
 
 jobs:
   build:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,15 @@ on:
     branches:
       - main
       - develop
+
+  pull_request_target:
+    types:
+      - opened
+    branches:
       - 'dependabot/**'
+    paths:
+      - 'composer.*'
+      - 'package*.json'
 
 env:
   DB_CONNECTION: mysql


### PR DESCRIPTION
As it turns out, dependabot doesn't have access to repository or any other secrets due to security concerns.  
This led to past PRs in this repository failing on tests, since dependabot PRs never had access to any secrets in any environment.

Luckily, GitHub offers the possibility to use the `pull_request_target` event to allow (limited) access:  
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

This PR should enable dependabot PRs to execute tests. Since we're not using any sensitive secrets in the Testing environment, we should be safe here.

I've limited the event to `pull_request_target` on `opened` pull requests that start with `dependabot/` changing the `composer.json`, `composer.lock`, `package.json` or `package-lock.json` files - we could also be very explicit and list all four files by their exact name, if that is a concern.