### PR TITLE
chore: use unique names for browser test artifacts on failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -159,13 +159,15 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4.4.0
       with:
-        name: screenshots
+        name: screenshots-${{ github.run_id }}
         path: tests/Browser/screenshots
+        retention-days: 7
 
     # If there's a failure, upload the Dusk console logs as an artifact
     - name: Upload Console Logs
       if: failure()
       uses: actions/upload-artifact@v4.4.0
       with:
-        name: console
+        name: console-${{ github.run_id }}
         path: tests/Browser/console
+        retention-days: 7


### PR DESCRIPTION
I've also added a duration of 7 days for retention, since I think that we shouldn't keep those longer than that.  
The respository default at this point is 90 days.