### PR TITLE
fix: Bootstrap function deprecations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.4.32",
                 "prettier": "^3.3.3",
-                "sass-embedded": "^1.79.4",
+                "sass-embedded": "1.77.5",
                 "tailwindcss": "^3.4.0",
                 "vite": "^5.0"
             }
@@ -32,10 +32,11 @@
             }
         },
         "node_modules/@bufbuild/protobuf": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.1.0.tgz",
-            "integrity": "sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==",
-            "dev": true
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+            "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+            "dev": true,
+            "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -1065,12 +1066,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/colorjs.io": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
-            "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-            "dev": true
-        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2097,216 +2092,231 @@
             }
         },
         "node_modules/sass-embedded": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.79.4.tgz",
-            "integrity": "sha512-3AATrtStMgxYjkit02/Ix8vx/P7qderYG6DHjmehfk5jiw53OaWVScmcGJSwp/d77kAkxDQ+Y0r+79VynGmrkw==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.5.tgz",
+            "integrity": "sha512-JQI8aprHDRSNK5exXsbusswTENQPJxW1QWUcLdwuyESoJClT1zo8e+4cmaV5OAU4abcRC6Av4/RmLocPdjcR3A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@bufbuild/protobuf": "^2.0.0",
+                "@bufbuild/protobuf": "^1.0.0",
                 "buffer-builder": "^0.2.0",
-                "colorjs.io": "^0.5.0",
                 "immutable": "^4.0.0",
                 "rxjs": "^7.4.0",
                 "supports-color": "^8.1.1",
                 "varint": "^6.0.0"
             },
-            "bin": {
-                "sass": "dist/bin/sass.js"
-            },
             "engines": {
                 "node": ">=16.0.0"
             },
             "optionalDependencies": {
-                "sass-embedded-android-arm": "1.79.4",
-                "sass-embedded-android-arm64": "1.79.4",
-                "sass-embedded-android-ia32": "1.79.4",
-                "sass-embedded-android-riscv64": "1.79.4",
-                "sass-embedded-android-x64": "1.79.4",
-                "sass-embedded-darwin-arm64": "1.79.4",
-                "sass-embedded-darwin-x64": "1.79.4",
-                "sass-embedded-linux-arm": "1.79.4",
-                "sass-embedded-linux-arm64": "1.79.4",
-                "sass-embedded-linux-ia32": "1.79.4",
-                "sass-embedded-linux-musl-arm": "1.79.4",
-                "sass-embedded-linux-musl-arm64": "1.79.4",
-                "sass-embedded-linux-musl-ia32": "1.79.4",
-                "sass-embedded-linux-musl-riscv64": "1.79.4",
-                "sass-embedded-linux-musl-x64": "1.79.4",
-                "sass-embedded-linux-riscv64": "1.79.4",
-                "sass-embedded-linux-x64": "1.79.4",
-                "sass-embedded-win32-arm64": "1.79.4",
-                "sass-embedded-win32-ia32": "1.79.4",
-                "sass-embedded-win32-x64": "1.79.4"
+                "sass-embedded-android-arm": "1.77.5",
+                "sass-embedded-android-arm64": "1.77.5",
+                "sass-embedded-android-ia32": "1.77.5",
+                "sass-embedded-android-x64": "1.77.5",
+                "sass-embedded-darwin-arm64": "1.77.5",
+                "sass-embedded-darwin-x64": "1.77.5",
+                "sass-embedded-linux-arm": "1.77.5",
+                "sass-embedded-linux-arm64": "1.77.5",
+                "sass-embedded-linux-ia32": "1.77.5",
+                "sass-embedded-linux-musl-arm": "1.77.5",
+                "sass-embedded-linux-musl-arm64": "1.77.5",
+                "sass-embedded-linux-musl-ia32": "1.77.5",
+                "sass-embedded-linux-musl-x64": "1.77.5",
+                "sass-embedded-linux-x64": "1.77.5",
+                "sass-embedded-win32-arm64": "1.77.5",
+                "sass-embedded-win32-ia32": "1.77.5",
+                "sass-embedded-win32-x64": "1.77.5"
             }
         },
         "node_modules/sass-embedded-android-arm": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.79.4.tgz",
-            "integrity": "sha512-YOVpDGDcwWUQvktpJhYo4zOkknDpdX6ALpaeHDTX6GBUvnZfx+Widh76v+QFUhiJQ/I/hndXg1jv/PKilOHRrw==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.5.tgz",
+            "integrity": "sha512-/DfNYoykqwMFduecqa8n0NH+cS6oLdCPFjwhe92efsOOt5WDYEOlolnhoOENZxqdzvSV+8axL+mHQ1Ypl4MLtg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-android-arm64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.79.4.tgz",
-            "integrity": "sha512-0JAZ8TtXYv9yI3Yasaq03xvo7DLJOmD+Exb30oJKxXcWTAV9TB0ZWKoIRsFxbCyPxyn7ouxkaCEXQtaTRKrmfw==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.5.tgz",
+            "integrity": "sha512-t4yIhK5OUpg1coZxFpDo3BhI2YVj21JxEd5SVI6FfcWD2ESroQWsC4cbq3ejw5aun8R1Kx6xH1EKxO8bSMvn1g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-android-ia32": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.79.4.tgz",
-            "integrity": "sha512-IjO3RoyvNN84ZyfAR5s/a8TIdNPfClb7CLGrswB3BN/NElYIJUJMVHD6+Y8W9QwBIZ8DrK1IdLFSTV8nn82xMA==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.5.tgz",
+            "integrity": "sha512-92dWhEbR0Z2kpjbpfOx4LM9wlNBSnDsRtwpkMUK8udQIE7uF3E4/Fsf/88IJk0MrRkk4iwrsxxiCb1bz2tWnHQ==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/sass-embedded-android-riscv64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.79.4.tgz",
-            "integrity": "sha512-uOT8nXmKxSwuIdcqvElVWBFcm/+YcIvmwfoKbpuuSOSxUe9eqFzxo+fk7ILhynzf6FBlvRUH5DcjGj+sXtCc3w==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-android-x64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.79.4.tgz",
-            "integrity": "sha512-W2FQoj3Z2J2DirNs3xSBVvrhMuqLnsqvOPulxOkhL/074+faKOZZnPx2tZ5zsHbY97SonciiU0SV0mm98xI42w==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.5.tgz",
+            "integrity": "sha512-lFnXz9lRnjRLJ8Y28ONJViID3rDq4p6LJ/9ByPk2ZnSpx5ouUjsu4AfrXKJ0jgHWBaDvSKSxq2fPpt5aMQAEZA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-darwin-arm64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.79.4.tgz",
-            "integrity": "sha512-pcYtbN1VUAAcfgyHeX8ySndDWGjIvcq6rldduktPbGGuAlEWFDfnwjTbv0hS945ggdzZ6TFnaFlLEDr0SjKzBA==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.5.tgz",
+            "integrity": "sha512-J3yP6w+xqPrGQE0+sO4Gam6kBDJL5ivgkFNxR0fVlvKeN5qVFYhymp/xGRRMxBrKjohEQtBGP431EzrtvUMFow==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-darwin-x64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.79.4.tgz",
-            "integrity": "sha512-ir8CFTfc4JLx/qCP8LK1/3pWv35nRyAQkUK7lBIKM6hWzztt64gcno9rZIk4SpHr7Z/Bp1IYWWRS4ZT+4HmsbA==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.5.tgz",
+            "integrity": "sha512-A9fh5tg4s0FidMTG31Vs8TzYZ3Mam/I/tfqvN0g512OhBajp/p2DJvBY+0Br2r+TNH1yGUXf2ZfULuTBFj5u8w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-linux-arm": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.79.4.tgz",
-            "integrity": "sha512-H/XEE3rY7c+tY0qDaELjPjC6VheAhBo1tPJQ6UHoBEf8xrbT/RT3dWiIS8grp9Vk54RCn05BEB/+POaljvvKGA==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.5.tgz",
+            "integrity": "sha512-O7gbOWJloxITBZNkpwChFltxofsnDUf+3pz7+q2ETQKvZQ3kUfFENAF37slo0bsHJ7IEpwJK3ZJlnhZvIgfhgw==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-linux-arm64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.79.4.tgz",
-            "integrity": "sha512-XIVn2mCuA422SR2kmKjF6jhjMs1Vrt1DbZ/ktSp+eR0sU4ugu2htg45GajiUFSKKRj7Sc+cBdThq1zPPsDLf1w==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.5.tgz",
+            "integrity": "sha512-LoN804X7QsyvT/h8UGcgBMfV1SdT4JRRNV+slBICxoXPKBLXbZm9KyLRCBQcMLLdlXSZdOfZilxUN1Bd2az6OA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-linux-ia32": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.79.4.tgz",
-            "integrity": "sha512-3nqZxV4nuUTb1ahLexVl4hsnx1KKwiGdHEf1xHWTZai6fYFMcwyNPrHySCQzFHqb5xiqSpPzzrKjuDhF6+guuQ==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.5.tgz",
+            "integrity": "sha512-KHNJymlEmjyJbhGfB34zowohjgMvv/qKVsDX5hPlar+qMh+cxJwfgPln1Zl9bfe9qLObmEV2zFA1rpVBWy4xGQ==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-linux-musl-arm": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.79.4.tgz",
-            "integrity": "sha512-HnbU1DEiQdUayioNzxh2WlbTEgQRBPTgIIvof8J63QLmVItUqE7EkWYkSUy4RhO+8NsuN9wzGmGTzFBvTImU7g==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.5.tgz",
+            "integrity": "sha512-TLhJzd1TJ0oX1oULobkWLMDLeErD27WbhdZqxtFvIqzyO+1TZPMwojhRX4YNWmHdmmYhIuXTR9foWxwL3Xjgsg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2316,13 +2326,14 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-arm64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.79.4.tgz",
-            "integrity": "sha512-C6qX06waPEfDgOHR8jXoYxl0EtIXOyBDyyonrLO3StRjWjGx7XMQj2hA/KXSsV+Hr71fBOsaViosqWXPzTbEiQ==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.5.tgz",
+            "integrity": "sha512-ZWl8K8rCL4/phm3IPWDADwjnYAiohoaKg7BKjGo+36zv8P0ocoA0A3j4xx7/kjUJWagOmmoTyYxoOu+lo1NaKw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2332,29 +2343,14 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-ia32": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.79.4.tgz",
-            "integrity": "sha512-y5b0fdOPWyhj4c+mc88GvQiC5onRH1V0iNaWNjsiZ+L4hHje6T98nDLrCJn0fz5GQnXjyLCLZduMWbfV0QjHGg==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.5.tgz",
+            "integrity": "sha512-83zNSgsIIc+tYQFKepFIlvAvAHnbWSpZ824MjqXJLeCbfzcMO8SZ/q6OA0Zd2SIrf79lCWI4OfPHqp1PI6M7HQ==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/sass-embedded-linux-musl-riscv64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.79.4.tgz",
-            "integrity": "sha512-G2M5ADMV9SqnkwpM0S+UzDz7xR2njCOhofku/sDMZABzAjQQWTsAykKoGmzlT98fTw2HbNhb6u74umf2WLhCfw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2364,29 +2360,14 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-x64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.79.4.tgz",
-            "integrity": "sha512-kQm8dCU3DXf7DtUGWYPiPs03KJYKvFeiZJHhSx993DCM8D2b0wCXWky0S0Z46gf1sEur0SN4Lvnt1WczTqxIBw==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.5.tgz",
+            "integrity": "sha512-/SW9ggXZJilbRbKvRHAxEuQM6Yr9piEpvK7/aDevFL2XFvBW9x+dTzpH5jPVEmM0qWdJisS1r5mEv8AXUUdQZg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/sass-embedded-linux-riscv64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.79.4.tgz",
-            "integrity": "sha512-GaTI/mXYWYSzG5wxtM4H2cozLpATyh+4l+rO9FFKOL8e1sUOLAzTeRdU2nSBYCuRqsxRuTZIwCXhSz9Q3NRuNA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2396,65 +2377,81 @@
             }
         },
         "node_modules/sass-embedded-linux-x64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.79.4.tgz",
-            "integrity": "sha512-f9laGkqHgC01h99Qt4LsOV+OLMffjvUcTu14hYWqMS9QVX5a4ihMwpf1NoAtTUytb7cVF3rYY/NVGuXt6G3ppQ==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.5.tgz",
+            "integrity": "sha512-3EmYeY+K8nMwIy1El9C+mPuONMQyXSCD6Yyztn3G7moPdZTqXrTL7kTJIl+SRq1tCcnOMMGXnBRE7Kpou1wd+w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "bin": {
+                "sass": "dart-sass/sass"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-win32-arm64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.79.4.tgz",
-            "integrity": "sha512-cidBvtaA2cJ6dNlwQEa8qak+ezypurzKs0h0QAHLH324+j/6Jum7LCnQhZRPYJBFjHl+WYd7KwzPnJ2X5USWnQ==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.5.tgz",
+            "integrity": "sha512-dwVFOqkyfCRQgQB8CByH+MG93fp7IsfFaPDDCQVzVFAT00+HXk/dWFPMnv65XDDndGwsUE1KlZnjg8iOBDlRdw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "bin": {
+                "sass": "dart-sass/sass.bat"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-win32-ia32": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.79.4.tgz",
-            "integrity": "sha512-hexdmNTIZGTKNTzlMcdvEXzYuxOJcY89zqgsf45aQ2YMy4y2M8dTOxRI/Vz7p4iRxVp1Jow6LCtaLHrNI2Ordg==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.5.tgz",
+            "integrity": "sha512-1ij/K5d2sHPJkytWiPJLoUOVHJOB6cSWXq7jmedeuGooWnBmqnWycmGkhBAEK/t6t1XgzMPsiJMGiHKh7fnBuA==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "bin": {
+                "sass": "dart-sass/sass.bat"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/sass-embedded-win32-x64": {
-            "version": "1.79.4",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.79.4.tgz",
-            "integrity": "sha512-73yrpiWIbti6DkxhWURklkgSLYKfU9itDmvHxB+oYSb4vQveIApqTwSyTOuIUb/6Da/EsgEpdJ4Lbj4sLaMZWA==",
+            "version": "1.77.5",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.5.tgz",
+            "integrity": "sha512-Pn6j0jDGeEAhuuVY0CaZaBa7yNkqimEsbUDYYuQ9xh+XdGvZ86SZf6HXHUVIyQUjHORLwQ5f0XoKYYzKfC0y9w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "bin": {
+                "sass": "dart-sass/sass.bat"
+            },
             "engines": {
                 "node": ">=14.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.4.32",
         "prettier": "^3.3.3",
-        "sass-embedded": "^1.79.4",
+        "sass-embedded": "1.77.5",
         "tailwindcss": "^3.4.0",
         "vite": "^5.0"
     }


### PR DESCRIPTION
This PR pins the version of `sass-embedded` to get rid of warnings that come from Bootstrap, since deprecated functions are in use.

Fixes #56 